### PR TITLE
Add macOS launcher compatibility

### DIFF
--- a/python/udp_to_websocket.py
+++ b/python/udp_to_websocket.py
@@ -43,7 +43,13 @@ MPS_TO_FPM = 196.85           # Convert meters per second to feet per minute
 # SimAPI file paths - SayIntentionsAI reads from a specific location
 def get_local_appdata_path():
     # Get the local appdata directory path where SayIntentionsAI expects SimAPI files
-    return os.path.join(os.environ.get('LOCALAPPDATA', ''), 'SayIntentionsAI')
+    # Cross-platform support for Windows and macOS
+    if os.name == 'nt':  # Windows
+        return os.path.join(os.environ.get('LOCALAPPDATA', ''), 'SayIntentionsAI')
+    else:  # macOS/Linux
+        # Use ~/Library/Application Support for macOS
+        home = os.path.expanduser('~')
+        return os.path.join(home, 'Library', 'Application Support', 'SayIntentionsAI')
 
 def ensure_simapi_dir():
     # Ensure the SayIntentionsAI directory exists in local appdata

--- a/start_aerofly_map.sh
+++ b/start_aerofly_map.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+echo "Starting Aerofly Moving Map..."
+echo
+
+# Start the UDP to WebSocket server in the background
+echo "Starting UDP to WebSocket server..."
+python3 python/udp_to_websocket.py &
+UDP_PID=$!
+
+# Wait a moment for the first server to start
+sleep 2
+
+# Start the HTTP server in the background
+echo "Starting HTTP server..."
+python3 -m http.server 8080 &
+HTTP_PID=$!
+
+# Wait a moment for the HTTP server to start
+sleep 3
+
+# Open the browser
+echo "Opening browser..."
+open http://localhost:8080/index.html
+
+echo
+echo "Aerofly Moving Map is starting up!"
+echo
+echo "The following servers should now be running:"
+echo "1. UDP to WebSocket Server (receives data from Aerofly FS 4) - PID: $UDP_PID"
+echo "2. HTTP Server (serves the web page) - PID: $HTTP_PID"
+echo "3. Browser with the moving map"
+echo
+echo "To stop the servers, press Ctrl+C or run: kill $UDP_PID $HTTP_PID"
+echo
+
+# Wait for user input to stop
+read -p "Press Enter to stop the servers..."
+kill $UDP_PID $HTTP_PID
+echo "Servers stopped."


### PR DESCRIPTION
Even if MacOS does not have SayIntentions.ai, it would be useful to have the aeroflyToSayIntentions to work the same way as the Windows version:
- Add cross-platform path handling for SimAPI files (Windows/macOS)
- Create macOS launcher script (start_aerofly_map.sh) equivalent to Windows batch file
- Use proper macOS paths: ~/Library/Application Support/SayIntentionsAI/
- Maintain backward compatibility with Windows LOCALAPPDATA paths
- Enable macOS users to run the application with proper server startup
Without the last points, the users need to start everything manually and then open via browser directly the index.html, as the localhost:8080 was not starting correctly.